### PR TITLE
Rewrite spec file

### DIFF
--- a/spec/container_number_validator/container_number_validator_spec.rb
+++ b/spec/container_number_validator/container_number_validator_spec.rb
@@ -2,36 +2,44 @@ require 'spec_helper'
 
 describe ContainerNumberValidator do
 
-  describe '#validate' do
-    context 'invalid values' do
-      context 'nil and empty values' do
-        it { ContainerNumberValidator.validate(nil).should be_false }
-        it { ContainerNumberValidator.validate('').should be_false }
+  context 'fails on nil and empty values' do
+    it "with nil" do
+      expect(subject.validate(nil)).to be_false
+    end
+
+    it "with empty string" do
+      expect(subject.validate('')).to be_false
+    end
+  end
+
+  context 'fails on invalid owner code and category indentifier' do
+    %w{1CLU812975-4 TCLU81A975-4 TCLU81-975-4 T3LU812975-4}.each do |value|
+      it "with #{value}" do
+        expect(subject.validate(value)).to be_false
       end
+    end
+  end
 
-      context 'check owner code and category indentifier string' do
-        %w{1CLU812975-4 TCLU81A975-4 TCLU81-975-4 T3LU812975-4}.each do |value|
-          it { ContainerNumberValidator.validate(value).should be_false }
-        end
+  context 'fails on invalid checksum' do
+    %w{TCLU812975-1 MOFU587008-2 DRYU413526-6 NYKU561651-8}.each do |value|
+      it "with #{value}" do
+        expect(subject.validate(value)).to be_false
+      end
+    end
+  end
 
-        context 'invalid checksum' do
-          %w{TCLU812975-1 MOFU587008-2 DRYU413526-6 NYKU561651-8}.each do |value|
-            it { ContainerNumberValidator.validate(value).should be_false }
-          end
-        end
+  context "passes on valid owner code and category identifier" do
+    %w{MOFU587008-7 DRYU413526-5 NYKU644101-8 KKFU137865-2 NYKU561651-2 KKFU760143-9 TCLU250850-8}.each do |value|
+      it "with #{value}" do
+        expect(subject.validate(value)).to be_true
+      end
+    end
+  end
 
-        context 'valid values' do
-          context 'check owner code and category indentifier string' do
-            # Different variations on string case
-            %w{TCLU812975-4 TCLU8129754 tclu8129754 tclu812975-4}.each do |value|
-              it { ContainerNumberValidator.validate(value).should be_true }
-            end
-
-            %w{MOFU587008-7 DRYU413526-5 NYKU644101-8 KKFU137865-2 NYKU561651-2 KKFU760143-9 TCLU250850-8}.each do |value|
-              it { ContainerNumberValidator.validate(value).should be_true }
-            end
-          end
-        end
+  context 'passes on mixed case valid owner code and category identifier' do
+    %w{TCLU812975-4 TCLU8129754 tclu8129754 tclu812975-4}.each do |value|
+      it "with #{value}" do
+        expect(subject.validate(value)).to be_true
       end
     end
   end


### PR DESCRIPTION
I reformatted the specs to be more intent-revealing and to use
the clear expectations (rspec-expect).

By doing this, the specs, when run with the document formatter, reveal a lot more about what this gem does:

```
ContainerNumberValidator
  passes on valid owner code and category identifier
    with NYKU561651-2
    with DRYU413526-5
    with KKFU760143-9
    with MOFU587008-7
    with KKFU137865-2
    with NYKU644101-8
    with TCLU250850-8
  fails on invalid owner code and category indentifier
    with 1CLU812975-4
    with TCLU81A975-4
    with TCLU81-975-4
    with T3LU812975-4
  fails on nil and empty values
    with nil
    with empty string
  fails on invalid checksum
    with TCLU812975-1
    with MOFU587008-2
    with DRYU413526-6
    with NYKU561651-8
  passes on mixed case valid owner code and category identifier
    with TCLU812975-4
    with TCLU8129754
    with tclu8129754
    with tclu812975-4

Finished in 0.00479 seconds
21 examples, 0 failures
```
